### PR TITLE
Minor bug fixes

### DIFF
--- a/eryn/backends/backend.py
+++ b/eryn/backends/backend.py
@@ -741,7 +741,7 @@ class Backend(object):
                 if chains.shape[2] == 1:
                     # If no multiple leaves, we squeeze and transpose to the
                     # right shape to pass to the psrf function, which is  (nwalkers, nsamples, ndim)
-                    chains_in = chains.squeeze().transpose((1, 0, 2))
+                    chains_in = chains.squeeze(axis=2).transpose((1, 0, 2))
                 else:
                     # Project onto the model dim all chains [in case of RJ and multiple leaves per branch]
                     inds = self.get_inds(discard=discard, thin=thin)[branch][

--- a/eryn/ensemble.py
+++ b/eryn/ensemble.py
@@ -956,6 +956,8 @@ class EnsembleSampler(object):
                         )
 
                     # update after diagnostic and stopping check
+                    # if updating and using burn_in, need to make sure it does not use
+                    # previous chain samples since they are not stored.
                     if (
                         self.update_iterations > 0
                         and self.update_fn is not None
@@ -1004,9 +1006,6 @@ class EnsembleSampler(object):
                 )
             initial_state = self._previous_state
 
-        # setup thin_by info
-        thin_by = 1 if "thin_by" not in kwargs else kwargs["thin_by"]
-
         # run burn in
         if burn is not None and burn != 0:
             # prepare kwargs that relate to burn
@@ -1015,14 +1014,6 @@ class EnsembleSampler(object):
             burn_kwargs["thin_by"] = 1
             i = 0
             for results in self.sample(initial_state, iterations=burn, **burn_kwargs):
-                # if updating and using burn_in, need to make sure it does not use
-                # previous chain samples since they are not stored.
-                if (
-                    self.update_iterations > 0
-                    and self.update_fn is not None
-                    and (i + 1) % (self.update_iterations * thin_by) == 0
-                ):
-                    self.update_fn(i, results, self)
                 i += 1
 
             # run post-burn update

--- a/eryn/moves/combine.py
+++ b/eryn/moves/combine.py
@@ -45,7 +45,7 @@ class CombineMove(Move):
         # set the accepted arrays for all moves
         assert isinstance(accepted, np.ndarray)
         for move in self.moves:
-            move.accepted = accepted
+            move.accepted = accepted.copy()
 
     @property
     def acceptance_fraction(self):

--- a/eryn/moves/group.py
+++ b/eryn/moves/group.py
@@ -130,7 +130,7 @@ class GroupMove(Move, ABC):
         # Run any move-specific setup.
         self.setup(state.branches)
 
-        if self.iter == 0 or self.iter % self.n_iter_update == 0:
+        if self.iter == 0:
             self.setup_friends(state.branches)
 
         if self.iter != 0 and self.iter % self.n_iter_update == 0:

--- a/eryn/moves/group.py
+++ b/eryn/moves/group.py
@@ -130,7 +130,7 @@ class GroupMove(Move, ABC):
         # Run any move-specific setup.
         self.setup(state.branches)
 
-        if self.iter == 0:
+        if self.iter == 0 or self.iter % self.n_iter_update == 0:
             self.setup_friends(state.branches)
 
         if self.iter != 0 and self.iter % self.n_iter_update == 0:


### PR DESCRIPTION
1. **[backend.py]** Add `axis=2` to the squeeze logic, so that it works correctly when there is a single leaf (i.e. we squeeze in the 'leaves' dimension).
2. **[combine.py]** Add `.copy()` to have independent (and correct) accepted arrays for each move.
3. **[group.py]** Remove condition when updating friends. Otherwise, the friends group is updated twice on each iteration.
4. **[ensemble.py]** Remove update_fn logic for burn-in in `run_mcmc`, because the logic is already inside the `sample` method.