### PR TITLE
Documentation page / tutorial edits

### DIFF
--- a/eryn/state.py
+++ b/eryn/state.py
@@ -395,6 +395,8 @@ class State(object):
             was used in this step. If dict, need to use ``branch_names`` for the keys.
             Input should be ``None`` if a complete :class:`.State` object is input for ``coords``.
             (default: ``None``)
+        branch_supplemental (object): :class:`BranchSupplemental` object specific to this branch.
+            (default: ``None``)
         log_like (ndarray[ntemps, nwalkers], optional): Log likelihoods
             for the  walkers at positions given by ``coords``.
             Input should be ``None`` if a complete :class:`.State` object is input for ``coords``.


### PR DESCRIPTION
Most of the edits I made were minor - I didn't change any underlying code, only edited the main tutorial notebook and some docstrings.

- In a recent update to eryn the new `branch_supplemental` was added.  This is a keyword argument for eryn.state.State(), but it did not appear in the docstring for the class.  I simply copied/pasted the docstring entry for `branch_supplemental` from eryn.state.Branch() into this docstring.
- In a recent update to eryn, the following spellling change had been made throughout the code: `branch_supplimental` --> `branch_supplemental`.  However, the change had not been made to the jupyter notebook tutorial, so I corrected this.
- Additionally, I made numerous small edits mostly to various visuals of the plots shown throughout the tutorial.