### PR TITLE
Add `install_requires` to `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,4 +35,12 @@ setup(
         "Programming Language :: Python :: 3",
     ],
     python_requires=">=3.6",
+    install_requires = [
+        "corner",
+        "tqdm",
+        "matplotlib",
+        "numpy",
+        "scipy",
+    ],
 )
+


### PR DESCRIPTION
Currently, pip-installing Eryn from PyPI *doesn't* pull the required `python` dependencies,
essentially because they are not in the `setup.py`.

This PR populates the `install_requires` field of `setup` to fix this.

I've refrained from grabbing them on-the-fly from `requirements.txt`, as such file
and `install_requires` [fulfill two different purposes](https://packaging.python.org/en/latest/discussions/install-requires-vs-requirements/).

Thanks, 