### PR TITLE
Normalizing flow proposal move

### DIFF
--- a/src/eryn/ensemble.py
+++ b/src/eryn/ensemble.py
@@ -1027,7 +1027,6 @@ class EnsembleSampler(object):
                         else:
                             moves_accepted_fraction = None
 
-                        print("RIGHT BEFORE SAVE", self.backend.filename)
                         self.backend.save_step(
                             state,
                             accepted,
@@ -1035,7 +1034,6 @@ class EnsembleSampler(object):
                             swaps_accepted=in_model_swaps,
                             moves_accepted_fraction=moves_accepted_fraction,
                         )
-                        print("RIGHT AFTER SAVE", self.backend.filename)
 
                     # update after diagnostic and stopping check
                     # if updating and using burn_in, need to make sure it does not use

--- a/src/eryn/moves/__init__.py
+++ b/src/eryn/moves/__init__.py
@@ -19,6 +19,7 @@ from .multipletry import MultipleTryMove
 from .group import GroupMove
 from .groupstretch import GroupStretchMove
 from .combine import CombineMove
+from .flow import FlowMove
 
 # from .basicmodelswaprj import BasicSymmetricModelSwapRJMove
 from .mtdistgen import MTDistGenMove
@@ -39,4 +40,5 @@ __all__ = [
     "GroupMove",
     "GroupStretchMove",
     "CombineMove",
+    "FlowMove",
 ]

--- a/src/eryn/moves/__init__.py
+++ b/src/eryn/moves/__init__.py
@@ -20,6 +20,7 @@ from .group import GroupMove
 from .groupstretch import GroupStretchMove
 from .combine import CombineMove
 from .flow import FlowMove
+from .priordraw import PriorDraw
 
 # from .basicmodelswaprj import BasicSymmetricModelSwapRJMove
 from .mtdistgen import MTDistGenMove
@@ -41,4 +42,5 @@ __all__ = [
     "GroupStretchMove",
     "CombineMove",
     "FlowMove",
+    "PriorDraw",
 ]

--- a/src/eryn/moves/flow.py
+++ b/src/eryn/moves/flow.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+
+"""Normalizing flow-based MCMC proposal moves.
+
+This module implements Metropolis-Hastings moves that use normalizing flows
+as the proposal distribution. The normalizing flow is expected to be pre-trained
+and is provided as some `flow` object to the proposal class.
+
+The implementation relies on the `coppuccino` package for normalizing flow
+operations (see https://github.com/aarondjohnson/coppuccino). Future development
+could generalize this to support other flow libraries.
+"""
+
+import numpy as np
+from .mh import MHMove
+
+try:
+    from coppuccino import sample, log_prob
+except ImportError:
+    pass
+
+__all__ = ["FlowMove"]
+
+
+class FlowMove(MHMove):
+    """A Metropolis step with a proposal from a normalizing flow.
+
+    This move generates proposals by sampling from a pre-trained normalizing
+    flow model.
+
+    Args:
+        flow (object): A trained normalizing flow model compatible with the `coppuccino` package.
+            Must support `sample()` and `log_prob()` functions for generating proposals
+            and computing log densities.
+        return_gpu (bool, optional): If ``use_gpu == True`` and
+            ``return_gpu == True``, returned arrays remain on GPU. (default: ``False``)
+        **kwargs (dict, optional): Kwargs for parent classes. (default: ``{}``)
+
+    """
+
+    def __init__(self, flow, return_gpu=False, **kwargs):
+        self.flow = flow
+        self.return_gpu = return_gpu
+        super(FlowMove, self).__init__(**kwargs)
+
+    def get_proposal(self, branches_coords, random, branches_inds=None, **kwargs):
+        """Generate proposal coordinates by sampling from normalizing flow.
+
+        Args:
+            branches_coords (dict): Keys are ``branch_names`` and values are
+                ``np.ndarray[ntemps, nwalkers, nleaves_max, ndim]``.
+            random (object): Current random state object.
+            branches_inds (dict, optional): Keys are ``branch_names`` and
+                values are ``np.ndarray[ntemps, nwalkers, nleaves_max]``
+                indicating active leaves. (default: ``None``)
+            **kwargs (dict, optional): Extra keyword arguments for proposal.
+
+        Returns:
+            tuple: (Proposed coordinates, factors) -> (dict, ndarray). The
+                factors are a ``ndarray[ntemps, nwalkers]`` of the change in flow density
+                between the current and proposed states.
+
+        """
+
+        # initialize output
+        q = {}
+        for i, (name, coords) in zip(branches_coords.keys(), branches_coords.values()):
+            ntemps, nwalkers, nleaves_max, ndim = coords.shape
+
+            # setup inds accordingly
+            if branches_inds is None:
+                inds = np.ones((ntemps, nwalkers, nleaves_max), dtype=bool)
+            else:
+                inds = branches_inds[name]
+
+            if i == 0:
+                factors = np.zeros((ntemps, nwalkers))
+
+            # get the proposal for this branch
+            inds_here = np.where(inds == True)
+
+            # copy coords
+            q[name] = coords.copy()
+
+            # get flow density at current state
+            flow_density_i = log_prob(self.flow, q[name][inds_here])
+
+            # propose new state from normalizing flow
+            new_coords = sample(
+                self.flow, n_samples=1, rng_seed=random.randint(1e10)
+            )  # arbitrary randint threshold, can change
+
+            # put into coords in proper location
+            q[name][inds_here] = new_coords.copy()
+
+            # get flow density at proposed state
+            flow_density_f = log_prob(self.flow, q[name][inds_here])
+
+            # update factors
+            factors += flow_density_i - flow_density_f
+
+        # handle periodic parameters
+        if self.periodic is not None:
+            q = self.periodic.wrap(
+                {
+                    name: tmp.reshape((ntemps * nwalkers,) + tmp.shape[-2:])
+                    for name, tmp in q.items()
+                },
+                xp=self.xp,
+            )
+
+            q = {
+                name: tmp.reshape(
+                    (
+                        ntemps,
+                        nwalkers,
+                    )
+                    + tmp.shape[-2:]
+                )
+                for name, tmp in q.items()
+            }
+
+        # if running on GPU but requested CPU returns, trasfer arrays back
+        if self.use_gpu and not self.return_gpu:
+            for name, arr in list(q.items()):
+                q[name] = arr.get()
+            factors = factors.get()
+
+        return q, factors

--- a/src/eryn/moves/flow.py
+++ b/src/eryn/moves/flow.py
@@ -83,7 +83,7 @@ class FlowMove(MHMove):
             q[name] = coords.copy()
 
             # get flow density at current state
-            flow_density_i = log_prob(self.flow, q[name][inds_here])
+            flow_density_i = log_prob(self.flow, q[name][inds_here]).reshape((ntemps, nwalkers))
 
             # propose new state from normalizing flow
             new_coords = sample(
@@ -94,7 +94,7 @@ class FlowMove(MHMove):
             q[name][inds_here] = new_coords.copy()
 
             # get flow density at proposed state
-            flow_density_f = log_prob(self.flow, q[name][inds_here])
+            flow_density_f = log_prob(self.flow, q[name][inds_here]).reshape((ntemps, nwalkers))
 
             # update factors
             factors += flow_density_i - flow_density_f

--- a/src/eryn/moves/flow.py
+++ b/src/eryn/moves/flow.py
@@ -64,7 +64,7 @@ class FlowMove(MHMove):
 
         # initialize output
         q = {}
-        for i, (name, coords) in zip(branches_coords.keys(), branches_coords.values()):
+        for i, (name, coords) in enumerate(zip(branches_coords.keys(), branches_coords.values())):
             ntemps, nwalkers, nleaves_max, ndim = coords.shape
 
             # setup inds accordingly

--- a/src/eryn/moves/priordraw.py
+++ b/src/eryn/moves/priordraw.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+
+import numpy as np
+from .mh import MHMove
+
+__all__ = ["PriorDraw"]
+
+
+class PriorDraw(MHMove):
+    "A Metropolis step with a proposal distribution drawing directly from the priors."
+
+    def __init__(self, priors, return_gpu=False, **kwargs):
+        if not isinstance(priors, dict):
+            self.priors = {"model_0": priors}
+        else:
+            self.priors = priors
+        self.return_gpu = return_gpu
+        super(PriorDraw, self).__init__(**kwargs)
+
+    def _compute_log_prior(self, coords, inds=None, supps=None, branch_supps=None):
+        """Calculate the vector of log-prior for the walkers.
+        This is copied directly from `ensemble.py` since the Move object has no
+        external knowledge of the sampler object and its attributes.
+
+        Args:
+            coords (dict): Keys are ``branch_names`` and values are
+                the position np.arrays[ntemps, nwalkers, nleaves_max, ndim].
+                This dictionary is created with the ``branches_coords`` attribute
+                from :class:`State`.
+            inds (dict, optional): Keys are ``branch_names`` and values are
+                the ``inds`` np.arrays[ntemps, nwalkers, nleaves_max] that indicates
+                which leaves are being used. This dictionary is created with the
+                ``branches_inds`` attribute from :class:`State`.
+                (default: ``None``)
+
+        Returns:
+            np.ndarray[ntemps, nwalkers]: Prior Values
+
+        """
+
+        # get number of temperature and walkers
+        ntemps, nwalkers, _, _ = coords[list(coords.keys())[0]].shape
+
+        if inds is None:
+            # default use all sources
+            inds = {
+                name: np.full(coords[name].shape[:-1], True, dtype=bool)
+                for name in coords
+            }
+
+        # take information out of dict and spread to x1..xn
+        x_in = {}
+
+        # flatten coordinate arrays
+        for i, (name, coords_i) in enumerate(coords.items()):
+            ntemps, nwalkers, nleaves_max, ndim = coords_i.shape
+
+            x_in[name] = coords_i.reshape(-1, ndim)
+
+        prior_out = np.zeros((ntemps, nwalkers))
+        for name in x_in:
+            ntemps, nwalkers, nleaves_max, ndim = coords[name].shape
+            prior_out_temp = (
+                self.priors[name]
+                .logpdf(x_in[name])
+                .reshape(ntemps, nwalkers, nleaves_max)
+            )
+
+            # fix any infs / nans from binaries that are not being used (inds == False)
+            prior_out_temp[~inds[name]] = 0.0
+
+            # vectorized because everything is rectangular (no groups to indicate model difference)
+            prior_out += prior_out_temp.sum(axis=-1)
+
+        if np.any(np.isnan(prior_out)):
+            raise ValueError("The prior function is returning Nan.")
+
+        return prior_out
+
+    def get_proposal(self, branches_coords, random, branches_inds=None, **kwargs):
+
+        # initialize output
+        q = {}
+        if branches_inds is None:
+            branches_inds = {
+                name: np.ones_like(coords, dtype=bool)
+                for name, coords in branches_coords.items()
+            }
+        for i, (name, coords) in enumerate(
+            zip(branches_coords.keys(), branches_coords.values())
+        ):
+            ntemps, nwalkers, nleaves_max, ndim = coords.shape
+
+            # setup inds accordingly (need to remain as dict)
+            inds = branches_inds[name]
+
+            # get the proposal for this branch
+            inds_here = np.where(inds == True)
+
+            if i == 0:
+                factors = np.zeros((ntemps, nwalkers))
+
+            # copy coords
+            q[name] = coords.copy()
+
+            # get log prior at current point
+            log_prior_i = self._compute_log_prior({name: q[name]}, inds=branches_inds)
+
+            # propose new state
+            new_coords = self.priors[name].rvs(size=(ntemps, nwalkers, nleaves_max))
+
+            # put into coords in proper location
+            q[name][inds_here] = new_coords[inds_here].copy()
+
+            # get log prior at new point
+            log_prior_f = self._compute_log_prior({name: q[name]}, inds=branches_inds)
+            factors += log_prior_i - log_prior_f
+
+        # handle periodic parameters
+        if self.periodic is not None:
+            q = self.periodic.wrap(
+                {
+                    name: tmp.reshape((ntemps * nwalkers,) + tmp.shape[-2:])
+                    for name, tmp in q.items()
+                },
+                xp=self.xp,
+            )
+
+            q = {
+                name: tmp.reshape(
+                    (
+                        ntemps,
+                        nwalkers,
+                    )
+                    + tmp.shape[-2:]
+                )
+                for name, tmp in q.items()
+            }
+
+        return q, factors


### PR DESCRIPTION
This PR adds a first-pass of a normalizing flow proposal distribution to `moves`. Developed as part of the 2026 LISA Sprint. The user can add a `FlowMove` to their sampler by providing some normalizing flow object when instantiating the move class.

UPDATE: also added another move that draws directly from the priors. The initial intention of this move is to do combined normalizing flow + prior draw moves to test cases.

Currently requires Aaron Johnson's `coppuccino` package for training and working with the flow objects. Further development could work around this requirement so as not to bring JAX and its offshoots into Eryn's dependencies.